### PR TITLE
Remove unnecessary require racket/hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
 odysseus/debug
+
+# Racket-generated files
+compiled/
+doc/
+
+# Editor-generated files
+*~
+\#*
+.\#*
+
+# OS-generated files
+.DS_Store

--- a/odysseus/optimize.rkt
+++ b/odysseus/optimize.rkt
@@ -1,6 +1,5 @@
 #lang racket
 
-(require (rename-in  racket/hash  (hash-union hash-union-racket)))
 (require compatibility/defmacro)
 (require "base.rkt")
 (require "list.rkt")


### PR DESCRIPTION
The racket/hash import isn't used anymore in this file anyway.

This avoids an import conflict between `hash-filter` from `racket/hash` and `hash-filter` from `"hash.rkt"` found in https://github.com/racket/racket/pull/4917#issuecomment-2035590697.